### PR TITLE
BounceMushroom Collision and Camera Shake Fixes

### DIFF
--- a/Assets/Scripts/Enemies/BounceMushroom.cs
+++ b/Assets/Scripts/Enemies/BounceMushroom.cs
@@ -4,17 +4,29 @@
  * 
  * Author: Cristion Dominguez
  * Date: 20 Nov. 2020
+ * 
  */
+
+ /*
+  * Revision Author: Cristion Dominguez
+  * Revision Date: 27 Nov. 2020
+  * 
+  * Modifications: Fixed a bug where if the Player interacted with multiple Bounce Mushrooms, they would undergo multiple pushing coroutines and have their velocity
+  * and angular velocity altered.
+  * 
+  */
 
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System;
+
 
 public class BounceMushroom : MonoBehaviour
 {
     [Header("Direction Control")]
     [SerializeField]
-    private bool directionCustomizable;  // bool representing whether the direction shall be defined by the script user
+    private bool directionCustomizable;  // Shall the direction be defined by the script user?
 
     [Header("Push Values")]
     [SerializeField]
@@ -28,17 +40,32 @@ public class BounceMushroom : MonoBehaviour
     private float directionInUnitCircleAngles = 0;  // direction the Player shall be bounced to in degrees relative to the x-axis
                                                     // (utilized only if directionCustomizable == true)
 
+    private bool bounceable = true;  // Shall the Bounce Mushroom bounce the Player? 
+
+    private static bool isBouncing = false;  // Is the Player currently bouncing away from a Bounce Mushroom? [Shared amidst all Bounce Mushrooms.]
+
+    private static float originalPlayerSpeed;  // original speed of Player ship [Shared amidst all Bounce Mushrooms.]
+
     /// <summary>
     /// Collects the Players transform and determines the position to push the Player to after collision with attached game object. Passes the Player transform and push position
-    /// into PushGameObject coroutine.
+    /// into PushGameObject coroutine. If the Player is bounced into another Bounce Mushroom, the push effect from the previous mushroom is cancelled.
     /// </summary>
     /// <param name="collision"> info about the collision </param>
     private void OnCollisionEnter(Collision collision)
     {
-        if (collision.transform.tag == "Player")
+        if (collision.transform.tag == "Player" && bounceable == true)
         {
+            // Acquire Player transform and initiate the direction variable.
             Transform player = collision.transform;
             Vector2 direction;
+
+            // If the Player is not under a bounce effect, save its original movement speed.
+            if (!isBouncing)
+                originalPlayerSpeed = player.GetComponent<ShipMovement>().xySpeed;
+
+            // Stop the Player from bouncing and do not allow the Bounce Mushroom to affect the Player anymore.
+            isBouncing = false;
+            bounceable = false;
 
             // If bounce direction is customizable, calculate a vector of size 1 from the origin facing directionInUnitCircleAngles degrees from the x-axis.
             // Otherwise, calculate a vector from the collision point to the Player game object center.
@@ -51,38 +78,52 @@ public class BounceMushroom : MonoBehaviour
             Vector2 pushPosition = new Vector2(direction.x, direction.y);
             pushPosition = pushPosition.normalized * pushDistance + new Vector2(player.localPosition.x, player.localPosition.y);
 
-            // Move Player game object.
+            // Push the Player gameobject.
             StartCoroutine(PushGameObject(player, pushPosition));
         }
     }
 
     /// <summary>
-    /// Moves Player game object to final position on the XY-plane for push duration.
+    /// Moves Player game object to final position on the XY-plane for push duration as long as the Player does not interact with another Bounce Mushroom.
     /// </summary>
     /// <param name="player"> transform of the Player </param>
     /// <param name="finalPosition"> position to move Player game object to </param>
     /// <returns></returns>
     private IEnumerator PushGameObject(Transform player, Vector2 finalPosition)
     {
-        float elapsedTime = 0;  // time since call of coroutine
+        float elapsedTime = 0;  // time since coroutine has first moved the Player
         Vector2 initialPosition = new Vector2(player.localPosition.x, player.localPosition.y);  // initial position of Player
         Vector2 currentPosition;  // current position of Player
 
-        // Save original Player movement speed and set current Player movement speed to 0.
-        float originalMovementSpeed = player.GetComponent<ShipMovement>().xySpeed;
+        // Set current Player movement speed to 0.
         player.GetComponent<ShipMovement>().xySpeed = 0;
 
-        // Whilst elapsed time < push duration, calculate and set the current position for Player as well as increment elapsed time.
+        // Allow the coroutine to push Player.
+        isBouncing = true;
+
+        // Whilst elapsed time < push duration, if the Player does not encounter another Bounce Mushroom, calculate and set the current position for Player 
+        // as well as increment elapsed time. Otherwise, reset the Player's velocity and angular velocity, and then exit coroutine.
         while (elapsedTime < pushDuration)
         {
-            currentPosition = Vector2.Lerp(initialPosition, finalPosition, elapsedTime / pushDuration);
-            player.transform.localPosition = new Vector3(currentPosition.x, currentPosition.y, player.localPosition.z);
-            elapsedTime += Time.deltaTime;
-            yield return null;
+            if (isBouncing == true)
+            {
+                currentPosition = Vector2.Lerp(initialPosition, finalPosition, elapsedTime / pushDuration);
+                player.transform.localPosition = new Vector3(currentPosition.x, currentPosition.y, player.localPosition.z);
+                elapsedTime += Time.deltaTime;
+                yield return null;
+            }
+            else
+            {
+                player.GetComponent<Rigidbody>().velocity = new Vector3(0, 0, 0);
+                player.GetComponent<Rigidbody>().angularVelocity = new Vector3(0, 0, 0);
+                yield break;
+            }
         }
 
-        // Place the Player at the final position and return Player movement speed back to original value.
+        // Place the Player at the final position, return Player movement speed back to original value, and notify other Bounce Mushrooms that the Player
+        // is not bouncing.
         player.transform.localPosition = finalPosition;
-        player.GetComponent<ShipMovement>().xySpeed = originalMovementSpeed;
+        player.GetComponent<ShipMovement>().xySpeed = originalPlayerSpeed;
+        isBouncing = false;
     }
 }

--- a/Assets/Scripts/Environment/SpeedTrigger.cs
+++ b/Assets/Scripts/Environment/SpeedTrigger.cs
@@ -1,13 +1,18 @@
 ﻿/*
- * Script triggers speed increase for dolly track when Player collides with attached GameObject. Can be permanent or temporary.
- * Script deals solely with local positions when transitioning camera.
- * 
- * RESTRICTIONS: X and Y positions after camera transition shall be the X and Y positions right before the transition.
- *               Shake duration can not exceed transition duration.
+ * Triggers speed increase/decrease for dolly track when Player collides with attached GameObject. Can be permanent or temporary depending on the ScreenShake script
+ * attached to Player gameobject.
  * 
  * Author: Cristion Dominguez
  * Date: 30 Oct. 2020
  */
+
+/*
+* Revision Author: Cristion Dominguez
+* Revision Date: 27 Nov. 2020
+* 
+* Modifications: Altered interaction with ScreenShake script revised on 27 Nov. 2020. Function remains the same.
+* 
+*/
 
 using System.Collections;
 using System.Collections.Generic;
@@ -18,11 +23,16 @@ public class SpeedTrigger : MonoBehaviour
     [Header("Speed Adjustment Values")]
     [SerializeField]
     private int dollyTrackSpeed = 10;  // new speed to set dolly track on
+
     [SerializeField]
     private float activeTimeForTemporarySpeed = 5;  // time temporary speed lasts for
-    private ScreenShake screenShake;
 
-    //BASICALLY HOW TO USE
+    private ScreenShake screenShake;  // instance of ScreenShake attached to Player
+
+    /// <summary>
+    /// If the attached gameobject collides with the Player, obtains ScreenShake script from Player and calls the AdjustSpeed coroutine.
+    /// </summary>
+    /// <param name="other"> the collided gameobject </param>
     private void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.tag == "Player")
@@ -33,38 +43,31 @@ public class SpeedTrigger : MonoBehaviour
     }
 
     /// <summary>
-    /// If speed adjustment is permanent, permantantly applies the new speed to the dolly track and calls the TransitionCamera coroutine once. Otherwise, temporarily applies the new
-    /// speed to the dolly track and calls the TransitionCamera coroutine twice.
+    /// If the camera transition for the Player is permanent, permantantly applies the new speed to the dolly track and calls the ScreenCamera method from ScreenShake;
+    /// otherwise, temporarily applies the new speed to the dolly track, calls the TransitionCamera coroutine from ScreenShake twice, and applies the initial speed
+    /// to the dolly track afterwards.
     /// </summary>
     private IEnumerator AdjustSpeed()
     {
-        float initialPositionZ;
-        float newPositionZ;
-
         // If speed adjustment is permanent, then only transition camera once and set a permanent speed for dolly track.
         if (screenShake.isPermanent == true)
         {
             screenShake.dollyCart.m_Speed = dollyTrackSpeed;  // apply new dolly track speed
-            initialPositionZ = screenShake.shipCamera.localPosition.z;  // save initial z position
-            newPositionZ = screenShake.shipCamera.localPosition.z - screenShake.cameraDistance;  // calculate new z position
-            screenShake.originalX_YPosition = new Vector2(screenShake.shipCamera.localPosition.x, screenShake.shipCamera.localPosition.y);  // the X and Y positions of camera before transitioning
+            screenShake.ShakeCamera();
 
-            StartCoroutine(screenShake.TransitionCamera(initialPositionZ, newPositionZ, true));  // move camera to new Z position w/ shake effect
             yield break;
         }
+
+        float initialPositionZ = screenShake.shipCamera.localPosition.z;  // save initial z position
+        float newPositionZ = -screenShake.cameraToPlayerDistance;  // determine new z position
+
         // If speed adjustment is temporary, then set a temporary speed for dolly tracks and transition twice (first w/ shake, then w/o shake).
         float initialSpeed = screenShake.dollyCart.m_Speed;  // save initial dolly track speed
         screenShake.dollyCart.m_Speed = dollyTrackSpeed;  // apply new dolly track speed
 
-        initialPositionZ = screenShake.shipCamera.localPosition.z;  // save initial z position
-        newPositionZ = screenShake.shipCamera.localPosition.z - screenShake.cameraDistance;  // calculate new z position
-        screenShake.originalX_YPosition = new Vector2(screenShake.shipCamera.localPosition.x, screenShake.shipCamera.localPosition.y);  // the X and Y positions of camera before transitioning
-
-        StartCoroutine(screenShake.TransitionCamera(initialPositionZ, newPositionZ, true));  // move camera to new Z position w/o shake effect
-
+        StartCoroutine(screenShake.TransitionCamera(initialPositionZ, newPositionZ, true));  // move camera to new Z position w shake effect
         yield return new WaitForSeconds(activeTimeForTemporarySpeed);  // wait activeTimeForTemporarySpeed until executing next instructions
-
-        StartCoroutine(screenShake.TransitionCamera(newPositionZ, initialPositionZ, false));  // move camera to initial Z position w/ shake effect
+        StartCoroutine(screenShake.TransitionCamera(newPositionZ, initialPositionZ, false));  // move camera to initial Z position w/o shake effect
 
         screenShake.dollyCart.m_Speed = initialSpeed;  // apply initial dolly track speed
     }

--- a/Assets/Scripts/Player/ScreenShake.cs
+++ b/Assets/Scripts/Player/ScreenShake.cs
@@ -1,21 +1,45 @@
-﻿using System.Collections;
+﻿/*
+ * Handles the transition and shake of the camera following the Player ship.
+ * 
+ * NOTES: If cameraToPlayerDistance is 0, then the script shall only shake the camera.
+ *        X and Y positions after camera transition shall be the X and Y positions right before the transition.
+ *        A camera transition event must not interrupt a running camera transition event.
+ * 
+ * 
+ * Authors: Cristion Dominguez / Brad P
+ * Date: 30 Oct. 2020
+ * 
+ */
+
+/*
+ * Revision Author: Cristion Dominguez
+ * Revision Date: 27 Nov. 2020
+ * 
+ * Modifications: Fixed a bug where if the Player interacted with multiple objects, the Ship Camera would no longer be centered on the Player and not shake for each
+ * encountered object.
+ * 
+ */
+
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class ScreenShake : MonoBehaviour
 {
     [SerializeField]
-    public bool isPermanent = true;  // bool representing whether speed adjustment is permanent
+    public bool isPermanent = true;  // Is the camera transition permanent?
 
     [SerializeField]
-    protected float displacementTime = 5;  // time camera is displaced from original position
+    protected float displacementTime = 5;  // time camera stays at displaced Z position if transition is temporary
 
     [SerializeField]
-    protected float transitionDuration = 1;  // time to reach desired Z displacement
+    protected float transitionDuration = 1;  // time to reach desired Z position
 
     [Header("Camera Displacement")]
     [SerializeField]
-    public float cameraDistance;  // value to displace the camera's Z local position; positive values moves camera away
+    public float cameraToPlayerDistance;  // distance the camera should move to relative to the Player gameobject; if value is 0,
+                                          // then current distance in active scene shall be preserved and the camera shall only
+                                          // shake
 
     [Header("Camera Shake")]
     [SerializeField]
@@ -30,7 +54,8 @@ public class ScreenShake : MonoBehaviour
     [SerializeField]
     protected float shakeDuration = 1;  // duration of shaking; value can not exceed transition duration
 
-    protected float traumaExponent = 2;
+    protected float traumaExponent = 2; // allows an exponential fall in shake magnitude
+
     [SerializeField]
     public Cinemachine.CinemachineDollyCart dollyCart;  // dolly track behavior script
 
@@ -40,11 +65,47 @@ public class ScreenShake : MonoBehaviour
 
     public Vector2 originalX_YPosition;  // original X and Y positions of the ship camera before transition
 
-    public void ShakeCamera() //for script to call
+    private IEnumerator cameraShake;  // camera shake event
+
+    private IEnumerator cameraTransition; // camera transition event
+
+    private bool isShaking = false; // Is the camera shaking?
+
+    private Vector2 initialLimits;  // movement limits of camera before transition or shake
+
+    /// <summary>
+    /// Transitions and/or shakes the camera. If the camera is not shaking when this method is called, the initial position limits and the original X and Y position of the camera
+    /// shall be saved; otherwise, the coroutine shaking the camera shall be stopped. Afterwards, if the camera to player distance is 0, then the camera shall only shake; otherwise,
+    /// the camera shall transition and shake.
+    /// </summary>
+    public void ShakeCamera()
     {
-        StartCoroutine(CameraMovement());
+        if (!isShaking)
+        {
+            originalX_YPosition = new Vector2(shipCamera.localPosition.x, shipCamera.localPosition.y);  // the X and Y positions of camera before transitioning
+            initialLimits = cameraScript.limits;  // saving initial camera limits
+        }
+        else
+            StopCoroutine(cameraShake);
+
+        if (cameraToPlayerDistance == 0)
+        {
+            cameraShake = RattleCamera();
+            StartCoroutine(cameraShake);
+        }
+        else
+        {
+            cameraTransition = MoveCamera();
+            StartCoroutine(cameraTransition);
+        }
     }
 
+    /// <summary>
+    /// Sets the shake intensity, frequency and duration for the Camera Shake event; then calls for the event.
+    /// </summary>
+    /// <param name="intensity"> shake intensity </param>
+    /// <param name="frequency"> shake frequency </param>
+    /// <param name="duration"> shake duration </param>
     public void ShakeCamera(float intensity, float frequency = 10f, float duration = 1f)
     {
         shakeIntensity = intensity;
@@ -53,67 +114,94 @@ public class ScreenShake : MonoBehaviour
         ShakeCamera();
     }
 
-    private IEnumerator CameraMovement()
+    /// <summary>
+    /// Transitions the camera to a new Z position if the transition is permanent; otherwise, transitions the camera to a new Z position and stays there until displacement time
+    /// is over, then transition the camera to its initial Z position.
+    /// </summary>
+    private IEnumerator MoveCamera()
     {
-        float initialPositionZ;
-        float newPositionZ;
+        float initialPositionZ = shipCamera.localPosition.z;  // save initial z position
+        float newPositionZ = -cameraToPlayerDistance;  // determine new z position
 
-        initialPositionZ = shipCamera.localPosition.z;  // save initial z position
-        newPositionZ = shipCamera.localPosition.z - cameraDistance;  // calculate new z position
-        originalX_YPosition = new Vector2(shipCamera.localPosition.x, shipCamera.localPosition.y);  // the X and Y positions of camera before transitioning
-
-        // If speed adjustment is permanent, then only transition camera once and set a permanent speed for dolly track.
+        // If camera transition is permanent, then only transition camera once.
         if (isPermanent == true)
         {
             StartCoroutine(TransitionCamera(initialPositionZ, newPositionZ, true));  // move camera to new Z position w/ shake effect
             yield break;
         }
 
-        StartCoroutine(TransitionCamera(initialPositionZ, newPositionZ, true));  // move camera to new Z position w/o shake effect
-
-        yield return new WaitForSeconds(displacementTime);  // wait activeTimeForTemporarySpeed until executing next instructions
-
-        StartCoroutine(TransitionCamera(newPositionZ, initialPositionZ, false));  // move camera to initial Z position w/ shake effect
+        // If camera transition is temporary, transition camera to a new Z position, wait until displacementTime is reached, and then return to initial Z position.
+        StartCoroutine(TransitionCamera(initialPositionZ, newPositionZ, true));  // move camera to new Z position w/ shake effect
+        yield return new WaitForSeconds(displacementTime);  // wait displacementTime until executing next coroutine
+        StartCoroutine(TransitionCamera(newPositionZ, initialPositionZ, false));  // move camera to initial Z position w/o shake effect
     }
 
-    public  IEnumerator TransitionCamera(float startPositionZ, float endPositionZ, bool doShake)
+    /// <summary>
+    /// Transitions camera from a starting Z position to an ending Z position for a transition duration. A camera shake can accompany this transition.
+    /// </summary>
+    /// <param name="startPositionZ"> starting Z position of the camera </param>
+    /// <param name="endPositionZ"> ending Z position of the camera </param>
+    /// <param name="doShake"> Should a shake coroutine accompany the transition coroutine? </param>
+    public IEnumerator TransitionCamera(float startPositionZ, float endPositionZ, bool doShake)
     {
         float elapsedTime = 0;  // time passed since call of method
-        float z, trauma;  // current Z position of camera; current trauma of camera shake (respectively)
-        float shake = Mathf.Pow(shakeIntensity, traumaExponent);
-        float perlinSeed = Random.value;  // seed for perlin noise (method that generates a psuedo-random value from 0 to 1)
+        float z; // current Z position of camera
 
-        Vector2 initialLimits = cameraScript.limits;  // saving initial camera limits
+        // Call the shake coroutine if doShake == true.
+        if (doShake)
+        {
+            cameraShake = RattleCamera();
+            StartCoroutine(cameraShake);
+        }
 
-        // Modify camera limits if shake is enabled.
-        if (doShake == true)
-            cameraScript.limits = new Vector2(shakeMagnitudeRatio.x * shake, shakeMagnitudeRatio.y * shake);
-
-        // Whilst elapsed time is less than transition duration, transition the camera towards the end Z position and shake the camera if option is enabled.
+        // Whilst elapsed time is less than transition duration, transition the camera towards the end Z position.
         while (elapsedTime < transitionDuration)
         {
             z = Mathf.Lerp(startPositionZ, endPositionZ, elapsedTime / transitionDuration);  // calculate current Z position
 
-            // If camera shake is enabled and elapsed time is less than shake duration, assign the X and Y positions psuedo-random values.
-            if (doShake == true && elapsedTime < shakeDuration)
-            {
-                trauma = Mathf.Lerp(shakeIntensity, 0, elapsedTime / shakeDuration);  // calculate new trauma value
-                shake = Mathf.Pow(trauma, traumaExponent);  // calculate new shake value
-
-                // Set camera X and Y positions to psuedo-random values and set Z position to the calculated Z value.
-                shipCamera.localPosition = new Vector3(
-                    shakeMagnitudeRatio.x * (Mathf.PerlinNoise(perlinSeed, Time.time * shakeFrequency) * 2 - 1) * shake,
-                    shakeMagnitudeRatio.y * (Mathf.PerlinNoise(perlinSeed + 1, Time.time * shakeFrequency) * 2 - 1) * shake,
-                    z);
-            }
-            // If camera shake is not enabled, then only change Z position to calculated Z value
-            else shipCamera.localPosition = new Vector3(originalX_YPosition.x, originalX_YPosition.y, z);
+            shipCamera.localPosition = new Vector3(shipCamera.localPosition.x, shipCamera.localPosition.y, z);  // set new camera position
 
             elapsedTime += Time.deltaTime;  // update elapsed time
             yield return null;
         }
 
-        shipCamera.localPosition = new Vector3(originalX_YPosition.x, originalX_YPosition.y, endPositionZ);  // snap camera to desired final position
-        cameraScript.limits = initialLimits;  // restore initial camera limits
+        // Snap camera to desired final position and notify script that camera is no longer transitioning.
+        shipCamera.localPosition = new Vector3(shipCamera.localPosition.x, shipCamera.localPosition.y, endPositionZ);
+    }
+
+    /// <summary>
+    /// Shakes camera for shake duration.
+    /// </summary>
+    private IEnumerator RattleCamera()
+    {
+        float elapsedTime = 0;  // time passed since call of method
+        float trauma;  // current trauma of camera shake
+        float shake = Mathf.Pow(shakeIntensity, traumaExponent); // percentage of max shake magnitude allowed, which shall decrease
+        float perlinSeed = Random.value;  // seed for perlin noise (method that generates a psuedo-random value from 0 to 1)
+
+        // Modify camera limits and notify script that the camera is shaking.
+        cameraScript.limits = new Vector2(shakeMagnitudeRatio.x * shake, shakeMagnitudeRatio.y * shake);
+        isShaking = true;
+
+        // Whilst elapsed time is less than shake duration, shake the camera.
+        while (elapsedTime < shakeDuration)
+        {
+            trauma = Mathf.Lerp(shakeIntensity, 0, elapsedTime / shakeDuration);  // calculate new trauma value
+            shake = Mathf.Pow(trauma, traumaExponent);  // calculate new shake value
+
+            // Set camera X and Y positions to psuedo-random values and preserve current Z position.
+            shipCamera.localPosition = new Vector3(
+                shakeMagnitudeRatio.x * (Mathf.PerlinNoise(perlinSeed, Time.time * shakeFrequency) * 2 - 1) * shake,
+                shakeMagnitudeRatio.y * (Mathf.PerlinNoise(perlinSeed + 1, Time.time * shakeFrequency) * 2 - 1) * shake,
+                shipCamera.localPosition.z);
+
+            elapsedTime += Time.deltaTime;  // update elapsed time
+            yield return null;
+        }
+
+        // Snap camera to desired final position, restore initial camera limits and notify script the camera is no longer shaking.
+        shipCamera.localPosition = new Vector3(originalX_YPosition.x, originalX_YPosition.y, shipCamera.localPosition.z);
+        cameraScript.limits = initialLimits;
+        isShaking = false;
     }
 }


### PR DESCRIPTION
Remedied the bugs where the Player gameobject would gain velocity and angular velocity whilst the Ship Camera would be permantly displaced in an undesirable location whenever multiple Bounce Mushrooms were encountered within short succession. Additionally, altered SpeedTrigger to better interact with the ScreenShake.

CAUTION: ScreenShake and SpeedTrigger shall likely have to be revisited since they are restricted in functionality. For example, a gameobject with the SpeedTrigger script attached can not control the transition distance from the camera to Player.